### PR TITLE
release: v0.2.5 worker uid detection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,10 +87,10 @@ MUTEKI_DEEPSEEK_API_KEY=sk-your-deepseek-key-here
 # `/btw` side-query worker timeout in seconds (default 240).
 # MUTEKI_BTW_WORKER_TIMEOUT=240
 #
-# Advanced: worker container user ownership. Defaults match the image's kali user
-# (1001:1001); change only for a custom worker image.
-# MUTEKI_WORKER_UID=1001
-# MUTEKI_WORKER_GID=1001
+# Advanced: worker container user ownership. By default Muteki reads the kali
+# UID/GID from the selected worker image; set these only to override a custom image.
+# MUTEKI_WORKER_UID=1000
+# MUTEKI_WORKER_GID=1000
 
 # ── Optional: docker-compose deployment (the unified control plane) ──────────
 # Only for `docker compose up` (web + workers both containerized). For a plain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable public release changes are tracked here.
 
+## 0.2.5 - 2026-06-30
+
+### Changed
+
+- Release metadata, package versions, and worker build examples now point at `0.2.5`.
+
+### Fixed
+
+- Resolved container workspace permission mismatches by detecting the worker image's actual `kali` UID/GID before chowning shared run state.
+
 ## 0.2.4 - 2026-06-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ MUTEKI_WORKER_IMAGE=ghcr.io/fishcodetech/muteki-worker-slim:latest ./run.sh web
 
 ```bash
 ./docker/worker/build.sh
-./docker/worker/build.sh ghcr.io/fishcodetech/muteki-worker 0.2.4
-./docker/worker-slim/build.sh ghcr.io/fishcodetech/muteki-worker-slim 0.2.4 amd64
+./docker/worker/build.sh ghcr.io/fishcodetech/muteki-worker 0.2.5
+./docker/worker-slim/build.sh ghcr.io/fishcodetech/muteki-worker-slim 0.2.5 amd64
 ```
 
 The full image is intentionally large (Kali headless + Ghidra + SageMath via conda + offline knowledge). Use the slim image only when you understand that workers may need to install more tooling during a run.

--- a/README_CN.md
+++ b/README_CN.md
@@ -227,8 +227,8 @@ MUTEKI_WORKER_IMAGE=ghcr.io/fishcodetech/muteki-worker-slim:latest ./run.sh web
 
 ```bash
 ./docker/worker/build.sh
-./docker/worker/build.sh ghcr.io/fishcodetech/muteki-worker 0.2.4
-./docker/worker-slim/build.sh ghcr.io/fishcodetech/muteki-worker-slim 0.2.4 amd64
+./docker/worker/build.sh ghcr.io/fishcodetech/muteki-worker 0.2.5
+./docker/worker-slim/build.sh ghcr.io/fishcodetech/muteki-worker-slim 0.2.5 amd64
 ```
 
 完整镜像会比较大(Kali headless + Ghidra + 经 conda 装的 SageMath + 离线知识库)。只有在你明确知道 worker 可以在运行中自行安装缺失工具时，才建议用 slim 镜像跑真实题目。

--- a/apps/web/ui/package-lock.json
+++ b/apps/web/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muteki-command-deck",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muteki-command-deck",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/xterm": "^5.5.0",

--- a/apps/web/ui/package.json
+++ b/apps/web/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muteki-command-deck",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "description": "Project Muteki web command deck — a conversation-first frontend over the agent SSE stream with a live fact graph, blackboard, worker dock, and HITL controls.",
   "scripts": {

--- a/docker/worker-slim/build.sh
+++ b/docker/worker-slim/build.sh
@@ -7,7 +7,7 @@
 #
 # Usage: ./docker/worker-slim/build.sh [repo] [version] [arch]
 #   repo:    image repository (default: muteki-worker-slim; e.g. ghcr.io/fishcodetech/muteki-worker-slim)
-#   version: version tag       (default: 0.2.4)
+#   version: version tag       (default: 0.2.5)
 #   arch:    amd64 | arm64     (default: HOST arch — arm64 on Apple Silicon)
 # Tags built: <repo>:<version> AND <repo>:latest.
 #
@@ -26,7 +26,7 @@
 set -euo pipefail
 
 REPO_IMAGE="${1:-muteki-worker-slim}"
-VERSION="${2:-0.2.4}"
+VERSION="${2:-0.2.5}"
 # Default arch = host arch (uname -m → docker/go naming). Override with 3rd arg.
 _host_arch="$(uname -m)"
 case "${_host_arch}" in

--- a/docker/worker/build.sh
+++ b/docker/worker/build.sh
@@ -6,12 +6,12 @@
 #
 # Usage: ./docker/worker/build.sh [repo] [version]
 #   repo:    image repository (default: muteki-worker; e.g. ghcr.io/fishcodetech/muteki-worker)
-#   version: version tag       (default: 0.2.4)
+#   version: version tag       (default: 0.2.5)
 # Tags built: <repo>:<version> AND <repo>:latest (code defaults to :latest).
 set -euo pipefail
 
 REPO_IMAGE="${1:-muteki-worker}"
-VERSION="${2:-0.2.4}"
+VERSION="${2:-0.2.5}"
 TAG="${REPO_IMAGE}:${VERSION}"
 LATEST="${REPO_IMAGE}:latest"
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/muteki/solver/container_exec.py
+++ b/muteki/solver/container_exec.py
@@ -96,21 +96,94 @@ _CONTAINER_BIN = {
 _HOST_DATA_ROOT = (os.environ.get("MUTEKI_HOST_DATA_ROOT") or "").strip()
 _CONTAINER_DATA_ROOT = (os.environ.get("MUTEKI_CONTAINER_DATA_ROOT") or _HOST_DATA_ROOT).strip()
 
-# The worker runs as the image's `kali` user (uid:gid 1001:1001 — see the slim &
-# Kali Dockerfiles). The run workspace is created HOST-side by the (root) web
-# process and bind-mounted at /home/kali/workspace, so it lands root-owned and
-# the kali worker can't WRITE it. The runtime_agent chowns each per-worker HOME +
-# cwd, but the SHARED state created before/outside a worker spawn — most importantly
-# graph/shared_graph.db, the team blackboard — stays root:root 0644, so a worker's
-# `blackboard.py write_fact` hits "attempt to write a readonly database" (every
-# engine that reaches for the live board: claude via the skill, codex via raw
-# sqlite). Chown the workspace tree to the worker uid when we bring the container
-# up so the shared board (and any pre-created file under the mount) is writable.
-_WORKER_UID = int(os.environ.get("MUTEKI_WORKER_UID", "1001"))
-_WORKER_GID = int(os.environ.get("MUTEKI_WORKER_GID", "1001"))
+# The worker runs as the image's `kali` user. Do NOT hard-code its uid/gid: the
+# Kali and slim Dockerfiles intentionally create the user by name, and different
+# base images may assign 1000, 1001, or another value. The run workspace is created
+# HOST-side by the (root) web process and bind-mounted at /home/kali/workspace, so
+# it lands root-owned and the kali worker can't WRITE it. Chown the workspace tree
+# to the image's actual kali uid/gid when we bring the container up so shared state
+# (graph/shared_graph.db, workspace/shared, etc.) is writable.
+_WORKER_USER = (os.environ.get("MUTEKI_WORKER_USER") or "kali").strip() or "kali"
+_WORKER_ID_FALLBACK = (1000, 1000)
+_WORKER_ID_CACHE: dict[str, tuple[int, int]] = {}
+_WORKER_ID_LOCK = threading.Lock()
 
 
-def _chown_tree_to_worker(root: str) -> None:
+def _env_int(name: str) -> Optional[int]:
+    raw = (os.environ.get(name) or "").strip()
+    if not raw:
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        return None
+    return value if value >= 0 else None
+
+
+def _fallback_worker_uid_gid() -> tuple[int, int]:
+    uid = _env_int("MUTEKI_WORKER_UID")
+    gid = _env_int("MUTEKI_WORKER_GID")
+    return (
+        uid if uid is not None else _WORKER_ID_FALLBACK[0],
+        gid if gid is not None else _WORKER_ID_FALLBACK[1],
+    )
+
+
+_WORKER_UID, _WORKER_GID = _fallback_worker_uid_gid()
+
+
+def _query_worker_uid_gid(image: str) -> tuple[int, int]:
+    """Read the worker uid/gid from the local worker image.
+
+    `docker run` is used instead of image metadata because the Dockerfiles create
+    `kali` by name and do not set Config.User to that uid. `image inspect` first
+    prevents an accidental pull when the image is missing.
+    """
+    if _docker("image", "inspect", image, timeout=20).returncode != 0:
+        return _fallback_worker_uid_gid()
+    quoted_user = shlex.quote(_WORKER_USER)
+    r = _docker(
+        "run", "--rm", "--entrypoint", "sh", image,
+        "-lc", f"id -u {quoted_user} && id -g {quoted_user}",
+        timeout=30,
+    )
+    if r.returncode != 0:
+        return _fallback_worker_uid_gid()
+    vals: list[int] = []
+    for line in (r.stdout or "").splitlines():
+        try:
+            vals.append(int(line.strip()))
+        except ValueError:
+            continue
+        if len(vals) == 2:
+            break
+    if len(vals) != 2:
+        return _fallback_worker_uid_gid()
+    uid_override = _env_int("MUTEKI_WORKER_UID")
+    gid_override = _env_int("MUTEKI_WORKER_GID")
+    return (
+        uid_override if uid_override is not None else vals[0],
+        gid_override if gid_override is not None else vals[1],
+    )
+
+
+def _worker_uid_gid(image: str = WORKER_IMAGE) -> tuple[int, int]:
+    """Actual uid/gid that host-created workspace files must be chowned to."""
+    uid_override = _env_int("MUTEKI_WORKER_UID")
+    gid_override = _env_int("MUTEKI_WORKER_GID")
+    if uid_override is not None and gid_override is not None:
+        return uid_override, gid_override
+    with _WORKER_ID_LOCK:
+        if image not in _WORKER_ID_CACHE:
+            _WORKER_ID_CACHE[image] = _query_worker_uid_gid(image)
+        uid, gid = _WORKER_ID_CACHE[image]
+    return (
+        uid_override if uid_override is not None else uid,
+        gid_override if gid_override is not None else gid,
+    )
+
+
+def _chown_tree_to_worker(root: str, *, image: str = WORKER_IMAGE) -> None:
     """Best-effort recursive chown of a host dir tree to the worker uid:gid so the
     bind-mounted `kali` worker can write shared state (the blackboard DB lives here).
     No-op when we're not root (bare-host dev: the web process already owns it and
@@ -121,14 +194,15 @@ def _chown_tree_to_worker(root: str) -> None:
             return
     except AttributeError:  # no geteuid (non-POSIX) — nothing to do
         return
+    uid, gid = _worker_uid_gid(image)
     def _chown_one(path: str) -> None:
         try:
             if os.path.islink(path):
                 lchown = getattr(os, "lchown", None)
                 if callable(lchown):
-                    lchown(path, _WORKER_UID, _WORKER_GID)
+                    lchown(path, uid, gid)
                 return
-            os.chown(path, _WORKER_UID, _WORKER_GID)
+            os.chown(path, uid, gid)
         except OSError:
             pass  # one stubborn entry shouldn't abort the whole sweep
 
@@ -348,7 +422,7 @@ def ensure_container(run_id: str, host_workspace: str, *,
     # is read-only to workers (sqlite "attempt to write a readonly database").
     # This runs before the FIRST worker spawns; the DB is created earlier (swarm
     # bootstrap), so a recursive chown of the tree covers it. Best-effort.
-    _chown_tree_to_worker(host_workspace)
+    _chown_tree_to_worker(host_workspace, image=image)
     mount_account_root = account_root
     if account_root:
         os.makedirs(account_root, exist_ok=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-muteki"
-version = "0.2.4"
+version = "0.2.5"
 description = "Project Muteki (無敵): autonomous multi-model CTF-solving AI agent swarm"
 requires-python = ">=3.13"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -571,7 +571,7 @@ wheels = [
 
 [[package]]
 name = "project-muteki"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

- bump release metadata and worker build examples to 0.2.5
- detect the selected worker image's actual `kali` UID/GID before chowning shared run workspace state
- document worker UID/GID env vars as optional overrides instead of fixed defaults

## Verification

- `uv run python -m py_compile muteki/solver/container_exec.py`
- local `muteki-worker:latest` resolves to `(1000, 1000)` via `_worker_uid_gid()`