### PR TITLE
release: 0.3.1 folder menu fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable public release changes are tracked here.
 
+## 0.3.1 - 2026-08-20
+
+### Fixed
+
+- The sidebar folder menu item **Delete folder** could not be clicked. The open menu overlapped the next folder row, and that later row received the click.
+
+### Changed
+
+- Package versions are `0.3.1`. Git tags and GHCR image tags keep the leading `v`, for example `v0.3.1`.
+
 ## 0.3.0 - 2026-08-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ muteki rollback                # switch back to the previous installed release
 muteki version                 # show the active version and install mode
 ```
 
-The same controls are available under **Settings → System update** in the Web command deck. Releases and images default to this repository and `ghcr.io/fishcodetech`. For the versioned container deployment, use `muteki upgrade --compose` with [`docker-compose.release.yml`](docker-compose.release.yml). If you publish your own tags and images, set `MUTEKI_RELEASE_REPOSITORY` and `MUTEKI_IMAGE_REGISTRY`; non-public GitHub Releases also need `MUTEKI_GITHUB_TOKEN`. Git tags and image tags use a leading `v`, for example `v0.3.0`.
+The same controls are available under **Settings → System update** in the Web command deck. Releases and images default to this repository and `ghcr.io/fishcodetech`. For the versioned container deployment, use `muteki upgrade --compose` with [`docker-compose.release.yml`](docker-compose.release.yml). If you publish your own tags and images, set `MUTEKI_RELEASE_REPOSITORY` and `MUTEKI_IMAGE_REGISTRY`; non-public GitHub Releases also need `MUTEKI_GITHUB_TOKEN`. Git tags and image tags use a leading `v`, for example `v0.3.1`.
 
 Recommended setting:
 
@@ -258,8 +258,8 @@ MUTEKI_WORKER_IMAGE=ghcr.io/fishcodetech/muteki-worker-slim:latest ./run.sh web
 
 ```bash
 ./docker/worker/build.sh
-./docker/worker/build.sh ghcr.io/fishcodetech/muteki-worker v0.3.0
-./docker/worker-slim/build.sh ghcr.io/fishcodetech/muteki-worker-slim v0.3.0 amd64
+./docker/worker/build.sh ghcr.io/fishcodetech/muteki-worker v0.3.1
+./docker/worker-slim/build.sh ghcr.io/fishcodetech/muteki-worker-slim v0.3.1 amd64
 ```
 
 The full image is intentionally large (Kali headless + Ghidra + SageMath via conda + offline knowledge). Use the slim image only when you understand that workers may need to install more tooling during a run.

--- a/README_CN.md
+++ b/README_CN.md
@@ -149,7 +149,7 @@ muteki rollback                # 回滚到上一已安装版本
 muteki version                 # 查看当前版本和安装形态
 ```
 
-Web 控制台的“设置 → 系统更新”提供相同操作。发布包和镜像默认来自本仓库和 `ghcr.io/fishcodetech`。版本化容器部署使用 `muteki upgrade --compose` 和 [`docker-compose.release.yml`](docker-compose.release.yml)。若自行发布 tag 和镜像，设置 `MUTEKI_RELEASE_REPOSITORY` 和 `MUTEKI_IMAGE_REGISTRY`；非公开 GitHub Release 还需要 `MUTEKI_GITHUB_TOKEN`。Git 标签和镜像标签带 `v`，例如 `v0.3.0`。
+Web 控制台的“设置 → 系统更新”提供相同操作。发布包和镜像默认来自本仓库和 `ghcr.io/fishcodetech`。版本化容器部署使用 `muteki upgrade --compose` 和 [`docker-compose.release.yml`](docker-compose.release.yml)。若自行发布 tag 和镜像，设置 `MUTEKI_RELEASE_REPOSITORY` 和 `MUTEKI_IMAGE_REGISTRY`；非公开 GitHub Release 还需要 `MUTEKI_GITHUB_TOKEN`。Git 标签和镜像标签带 `v`，例如 `v0.3.1`。
 
 推荐设置项：
 
@@ -260,8 +260,8 @@ MUTEKI_WORKER_IMAGE=ghcr.io/fishcodetech/muteki-worker-slim:latest ./run.sh web
 
 ```bash
 ./docker/worker/build.sh
-./docker/worker/build.sh ghcr.io/fishcodetech/muteki-worker v0.3.0
-./docker/worker-slim/build.sh ghcr.io/fishcodetech/muteki-worker-slim v0.3.0 amd64
+./docker/worker/build.sh ghcr.io/fishcodetech/muteki-worker v0.3.1
+./docker/worker-slim/build.sh ghcr.io/fishcodetech/muteki-worker-slim v0.3.1 amd64
 ```
 
 完整镜像会比较大(Kali headless + Ghidra + 经 conda 装的 SageMath + 离线知识库)。只有在你明确知道 worker 可以在运行中自行安装缺失工具时，才建议用 slim 镜像跑真实题目。

--- a/apps/web/ui/app/globals.css
+++ b/apps/web/ui/app/globals.css
@@ -5186,6 +5186,13 @@ button.ws2-overview-tr:hover { background: var(--ink-wash); }
   position: relative;
   z-index: 1;
 }
+/* Open ⋯ menus overflow their row. Equal-z siblings later in the list would
+   intercept clicks on the overflowing items (folder "Delete" sits over the
+   next folder). Raise the open host above its neighbours. */
+.selection-glide-host > .rail-folder.menu-open,
+.selection-glide-host .thread-item.menu-open {
+  z-index: 90;
+}
 
 /* The shared layer owns selected backgrounds; items continue to own content,
    focus rings and semantic colours. */

--- a/apps/web/ui/components/ThreadRail.tsx
+++ b/apps/web/ui/components/ThreadRail.tsx
@@ -343,7 +343,7 @@ export function ThreadRail({
                   )}
                   <span className="rail-folder-count">{items.length}</span>
                 </button>
-                <div className="row-menu">
+                <div className={`row-menu ${menuFor === `folder:${f.id}` ? "menu-open" : ""}`}>
                   <button className="dots" title={t("rail.menu.moreActions")} aria-label={t("rail.menu.moreActions")}
                     onClick={(e) => { e.stopPropagation(); setMenuFor((cur) => (cur === `folder:${f.id}` ? null : `folder:${f.id}`)); }}><Icon name="more" size={15} /></button>
                   {menuFor === `folder:${f.id}` && (

--- a/apps/web/ui/package-lock.json
+++ b/apps/web/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muteki-command-deck",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muteki-command-deck",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/xterm": "^5.5.0",

--- a/apps/web/ui/package.json
+++ b/apps/web/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muteki-command-deck",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "description": "Project Muteki web command deck — a conversation-first frontend over the agent SSE stream with a live fact graph, blackboard, worker dock, and HITL controls.",
   "scripts": {

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -1,11 +1,11 @@
 # Project Muteki 版本化生产部署。
 #
 # 公开默认镜像仓库是 ghcr.io/fishcodetech。
-# Git / GHCR 标签带 v，例如 v0.3.0。
+# Git / GHCR 标签带 v，例如 v0.3.1。
 # 私有 GHCR 需要先 docker login ghcr.io，并设置 MUTEKI_IMAGE_REGISTRY。
 #
 # MUTEKI_IMAGE_REGISTRY=ghcr.io/fishcodetech \
-# MUTEKI_RELEASE_VERSION=v0.3.0 \
+# MUTEKI_RELEASE_VERSION=v0.3.1 \
 # MUTEKI_HOST_DATA_ROOT=/opt/muteki/data \
 # MUTEKI_WEB_PASSWORD=... docker compose -f docker-compose.release.yml up -d --wait
 
@@ -17,7 +17,7 @@ networks:
 
 services:
   web-api:
-    image: ${MUTEKI_IMAGE_REGISTRY:-ghcr.io/fishcodetech}/muteki-web:${MUTEKI_RELEASE_VERSION:-v0.3.0}
+    image: ${MUTEKI_IMAGE_REGISTRY:-ghcr.io/fishcodetech}/muteki-web:${MUTEKI_RELEASE_VERSION:-v0.3.1}
     networks: [muteki_net]
     ports:
       - "${MUTEKI_API_PORT:-8000}:8000"
@@ -36,8 +36,8 @@ services:
       MUTEKI_COORDINATOR_CONTROL_ROOT: "${MUTEKI_HOST_DATA_ROOT}/coordinator-control"
       MUTEKI_WEB_BIND: "0.0.0.0"
       MUTEKI_WEB_PASSWORD: "${MUTEKI_WEB_PASSWORD:?set MUTEKI_WEB_PASSWORD}"
-      MUTEKI_WORKER_IMAGE: "${MUTEKI_IMAGE_REGISTRY:-ghcr.io/fishcodetech}/muteki-worker:${MUTEKI_RELEASE_VERSION:-v0.3.0}"
-      MUTEKI_WORKER_IMAGE_VERSION: "${MUTEKI_RELEASE_VERSION:-v0.3.0}"
+      MUTEKI_WORKER_IMAGE: "${MUTEKI_IMAGE_REGISTRY:-ghcr.io/fishcodetech}/muteki-worker:${MUTEKI_RELEASE_VERSION:-v0.3.1}"
+      MUTEKI_WORKER_IMAGE_VERSION: "${MUTEKI_RELEASE_VERSION:-v0.3.1}"
       MUTEKI_RELEASE_REPOSITORY: "${MUTEKI_RELEASE_REPOSITORY:-FishCodeTech/muteki}"
       MUTEKI_IMAGE_REGISTRY: "${MUTEKI_IMAGE_REGISTRY:-ghcr.io/fishcodetech}"
       MUTEKI_GITHUB_TOKEN: "${MUTEKI_GITHUB_TOKEN:-}"
@@ -53,7 +53,7 @@ services:
     restart: unless-stopped
 
   ui:
-    image: ${MUTEKI_IMAGE_REGISTRY:-ghcr.io/fishcodetech}/muteki-ui:${MUTEKI_RELEASE_VERSION:-v0.3.0}
+    image: ${MUTEKI_IMAGE_REGISTRY:-ghcr.io/fishcodetech}/muteki-ui:${MUTEKI_RELEASE_VERSION:-v0.3.1}
     networks: [muteki_net]
     ports:
       - "${MUTEKI_UI_PORT:-3001}:3001"

--- a/docker/worker-slim/build.sh
+++ b/docker/worker-slim/build.sh
@@ -7,7 +7,7 @@
 #
 # Usage: ./docker/worker-slim/build.sh [repo] [version] [arch]
 #   repo:    image repository (default: muteki-worker-slim; e.g. ghcr.io/fishcodetech/muteki-worker-slim)
-#   version: version tag       (default: v0.3.0; GHCR release tags keep the leading v)
+#   version: version tag       (default: v0.3.1; GHCR release tags keep the leading v)
 #   arch:    amd64 | arm64     (default: HOST arch — arm64 on Apple Silicon)
 # Tags built: <repo>:<version> AND <repo>:latest.
 #
@@ -26,7 +26,7 @@
 set -euo pipefail
 
 REPO_IMAGE="${1:-muteki-worker-slim}"
-VERSION="${2:-v0.3.0}"
+VERSION="${2:-v0.3.1}"
 # Default arch = host arch (uname -m → docker/go naming). Override with 3rd arg.
 _host_arch="$(uname -m)"
 case "${_host_arch}" in

--- a/docker/worker/build.sh
+++ b/docker/worker/build.sh
@@ -6,12 +6,12 @@
 #
 # Usage: ./docker/worker/build.sh [repo] [version]
 #   repo:    image repository (default: muteki-worker; e.g. ghcr.io/fishcodetech/muteki-worker)
-#   version: version tag       (default: v0.3.0; GHCR release tags keep the leading v)
+#   version: version tag       (default: v0.3.1; GHCR release tags keep the leading v)
 # Tags built: <repo>:<version> AND <repo>:latest (code defaults to :latest).
 set -euo pipefail
 
 REPO_IMAGE="${1:-muteki-worker}"
-VERSION="${2:-v0.3.0}"
+VERSION="${2:-v0.3.1}"
 TAG="${REPO_IMAGE}:${VERSION}"
 LATEST="${REPO_IMAGE}:latest"
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/muteki/solver/container_exec.py
+++ b/muteki/solver/container_exec.py
@@ -59,7 +59,7 @@ from muteki.solver.credential_accounts import CONTAINER_ACCOUNTS_ROOT
 # at runtime; do not bake claude/codex/cursor login state into this image.
 # One generic worker image (NOT a per-recipe tag), published to Docker Hub so any
 # host can `docker pull` it. Default to the moving :latest; override with
-# MUTEKI_WORKER_IMAGE to pin a version (e.g. ghcr.io/fishcodetech/muteki-worker:v0.3.0).
+# MUTEKI_WORKER_IMAGE to pin a version (e.g. ghcr.io/fishcodetech/muteki-worker:v0.3.1).
 WORKER_IMAGE = os.environ.get("MUTEKI_WORKER_IMAGE", "ghcr.io/fishcodetech/muteki-worker:latest")
 CONTAINER_WORKSPACE = "/home/kali/workspace"
 CONTAINER_CONTROL_DIR = "/run/muteki/control"  # bind-mounted; carries the per-run token

--- a/muteki/version.py
+++ b/muteki/version.py
@@ -8,7 +8,7 @@ from importlib import metadata
 from pathlib import Path
 from typing import Any
 
-FALLBACK_VERSION = "0.3.0"
+FALLBACK_VERSION = "0.3.1"
 
 
 def project_root() -> Path:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "project-muteki"
-version = "0.3.0"
+version = "0.3.1"
 description = "Project Muteki (無敵): autonomous multi-model CTF-solving AI agent swarm"
 requires-python = ">=3.13"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -593,7 +593,7 @@ wheels = [
 
 [[package]]
 name = "project-muteki"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary
- Sync public `main` to private `v0.3.1` (`7c6ce1f5`).
- Fix the sidebar folder menu: **Delete folder** could not be clicked because the next folder row sat above the overflowing menu.
- Bump package versions to `0.3.1`. Git / GHCR tags keep the leading `v`.

This PR only updates the public snapshot. It does not merge itself.

## Test plan
- [x] Private `main` and tag `v0.3.1` pushed to `jiayuqi7813/muteki`
- [x] Snapshot scan from `publish.sh` passed (no private paths in this 14-file delta)
- [ ] Public CI on this PR
- [ ] After merge, `muteki version` / install path still reads `0.3.1`


Made with [Cursor](https://cursor.com)